### PR TITLE
#28 : Cart_도메인 설계

### DIFF
--- a/keypang/src/main/java/portfolio/keypang/domain/cart/Cart.java
+++ b/keypang/src/main/java/portfolio/keypang/domain/cart/Cart.java
@@ -1,0 +1,30 @@
+package portfolio.keypang.domain.cart;
+
+import static jakarta.persistence.GenerationType.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Cart {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+  @OneToMany(mappedBy = "cart" , orphanRemoval = true)
+  private Set<CartItem> wishList = new HashSet<>();
+
+  public void addCartItem(CartItem cartItem) {
+    wishList.add(cartItem);
+  }
+
+}

--- a/keypang/src/main/java/portfolio/keypang/domain/cart/CartItem.java
+++ b/keypang/src/main/java/portfolio/keypang/domain/cart/CartItem.java
@@ -1,0 +1,37 @@
+package portfolio.keypang.domain.cart;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import portfolio.keypang.domain.Item.Item;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CartItem {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+  @ManyToOne
+  @JoinColumn(name = "cart_id")
+  private Cart cart;
+  @ManyToOne
+  @JoinColumn(name = "item_id")
+  private Item item;
+
+  @Builder
+  public CartItem(Cart cart, Item item) {
+    this.cart = cart;
+    this.item = item;
+  }
+
+}

--- a/keypang/src/main/java/portfolio/keypang/domain/cart/CartItemRepository.java
+++ b/keypang/src/main/java/portfolio/keypang/domain/cart/CartItemRepository.java
@@ -1,0 +1,7 @@
+package portfolio.keypang.domain.cart;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartItemRepository extends JpaRepository<CartItem,Long> {
+
+}

--- a/keypang/src/main/java/portfolio/keypang/domain/cart/CartRepository.java
+++ b/keypang/src/main/java/portfolio/keypang/domain/cart/CartRepository.java
@@ -1,0 +1,7 @@
+package portfolio.keypang.domain.cart;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartRepository extends JpaRepository<Cart,Long> {
+
+}

--- a/keypang/src/main/java/portfolio/keypang/domain/users/user/User.java
+++ b/keypang/src/main/java/portfolio/keypang/domain/users/user/User.java
@@ -3,12 +3,16 @@ package portfolio.keypang.domain.users.user;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import portfolio.keypang.domain.cart.Cart;
 import portfolio.keypang.domain.users.common.AuthInfo;
 import portfolio.keypang.domain.users.common.UserLevel;
 
@@ -30,6 +34,10 @@ public class User extends AuthInfo {
   @Column(nullable = false)
   private boolean phoneVerified = false;
 
+  @OneToOne(fetch = FetchType.LAZY, orphanRemoval = true)
+  @JoinColumn(name = "CART_ID")
+  private Cart cart;
+
 
   @Builder
   public User(String username, String phone, UserLevel userLevel,
@@ -48,6 +56,7 @@ public class User extends AuthInfo {
   public void isPhoneVerified(boolean phoneVerified) {
     this.phoneVerified = phoneVerified;
   }
+
   public void updateLevel(UserLevel userLevel) {
     this.userLevel = userLevel;
   }


### PR DESCRIPTION
- 유저는 하나의 장바구니만을 가지고 있으며 장바구니 또한 여려 유저가 공용으로 사용하지 못하기에 OneToOne으로 사용하였으며 Cart로 User를 찾는 경우는 없다 생각이 되어 User에만 설정하였다
- Cart와 Item 은 ManyToMany관계로 생각하여 CartItem이라는 관계테이블을 생성하여 ManyToOne으로 설계하였다